### PR TITLE
Don't download and import the database dump again if it's already present.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,6 +81,11 @@
   set_fact: epoch="{{ lookup('pipe','date +%Y%m%d%H%M%S') }}"
   when: restore_db_backup or restore_files_backup
 
+- name: Checking if DB backup is already downloaded
+  stat:
+    path: "/tmp/{{ database_backup_name }}"
+  register: drupal_db_dump
+
 - name: Retrieve DB backup from s3
   s3:
     region: "{{ region }}"
@@ -90,14 +95,14 @@
     bucket: "{{ s3_bucket }}"
     object: "{{ database_backup_name }}"
     dest: "/tmp/{{ database_backup_name }}"
-  when: restore_db_backup and db_backup_url is not defined
+  when: (not drupal_db_dump.stat.exists) and restore_db_backup and db_backup_url is not defined
 
 - name: Import the DB backup
   mysql_db:
     state: import
     name: "{{ drupal_mysql_database }}"
     target: "/tmp/{{ database_backup_name }}"
-  when: restore_db_backup and db_backup_url is not defined
+  when: (not drupal_db_dump.stat.exists) and restore_db_backup and db_backup_url is not defined
 
 - name: Retrieve files backup from s3
   s3:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,7 +102,7 @@
     state: import
     name: "{{ drupal_mysql_database }}"
     target: "/tmp/{{ database_backup_name }}"
-  when: drupal_db_dump.stat.exists and drupal_bootstrapped.rc != 0 and restore_db_backup and db_backup_url is not defined
+  when: drupal_bootstrapped.rc != 0 and restore_db_backup and db_backup_url is not defined
 
 - name: Retrieve files backup from s3
   s3:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,7 +102,7 @@
     state: import
     name: "{{ drupal_mysql_database }}"
     target: "/tmp/{{ database_backup_name }}"
-  when: (not drupal_db_dump.stat.exists) and restore_db_backup and db_backup_url is not defined
+  when: drupal_db_dump.stat.exists and drupal_bootstrapped.rc != 0 and restore_db_backup and db_backup_url is not defined
 
 - name: Retrieve files backup from s3
   s3:


### PR DESCRIPTION
Needs discussion?  I've made it so that the import only happens when the dump exists AND Drupal _can't_ be bootstrapped.  One of the things which is really annoying (probably, I'm not developing on this stack ... but _"as a Drupal developer"_ ...) is having to recreate users/ content/ language table entries/ etc after reimporting a database.