### PR TITLE
Download and enable devel module to ensure DevelMailLog can be used.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -224,3 +224,14 @@
   args:
     chdir: "{{ doc_root }}"
   when: not restore_files_backup
+
+# Download and enable the devel module
+- name: Install the devel drupal module
+  command: "/usr/local/bin/drush pm-download devel -y"
+  args:
+    chdir: "{{ doc_root }}"
+
+- name: Enable the devel module
+  command: "/usr/local/bin/drush pm-enable devel -y"
+  args:
+    chdir: "{{ doc_root }}"


### PR DESCRIPTION
So ... the idea is that I've only just noticed we have Sendmail installed in vagrant, this is to prevent mails being sent to users from development environments.

https://www.drupal.org/node/201981

Will require a secondary step to the settings file upstart repo ~ adding;

`$conf['mail_system'] = array('default-system' => 'DevelMailLog');`