### PR TITLE
Add optional DB prefix to settings.php...

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Requires a working python 2.7 installation in the base vagrant box being used
 - `drupal_mysql_user` - User to create in the mysql database for drupal. (**root**)
 - `drupal_mysql_password` - Password to set in mysql for the drupal mysql user. Note that this has no effect when using root user.
 - `drupal_mysql_database` - MySQL database name for drupal database. (**drupal**)
+- `drupal_mysql_prefix` - Optional prefix for drupal database.
 - `doc_root` -  Full path to the website file dir. (**/var/www**)
 - `memcache_key_prefix` - Memcache key prefix to use. (**drupalvagrant**)
 - `restore_db_backup` - Restore DB archive from s3. (**false**)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 drupal_mysql_user: root
 drupal_mysql_password: root
 drupal_mysql_database: drupal
+drupal_mysql_prefix: ""
 doc_root: /var/www
 memcache_key_prefix: drupalvagrant
 restore_db_backup: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -174,7 +174,7 @@
   tags: update
 
 - name: Check if Drupal Features are enabled
-  command: '/usr/bin/mysql -N -s -u {{ drupal_mysql_user }} -p{{ drupal_mysql_password }} -e "SELECT 1 FROM system WHERE name = ''features'' AND status = 1;" {{ drupal_mysql_database }}'
+  command: "/usr/local/bin/drush -r /var/www sql-query 'SELECT COUNT(*) FROM {{ (drupal_mysql_prefix != '') | ternary(drupal_mysql_prefix  + '_', '') }}system WHERE name = \"features\" AND status = 1;'"
   when: drupal_site_install.skipped
   tags: update
   register: drupal_enabled_features
@@ -193,7 +193,7 @@
   when: drupal_site_install.skipped
 
 - name: Check if Drupal Set Environment is enabled
-  command: '/usr/bin/mysql -N -s -u {{ drupal_mysql_user }} -p{{ drupal_mysql_password }} -e "SELECT 1 FROM system WHERE name = ''set_environment'' AND status = 1;" {{ drupal_mysql_database }}'
+  command: "/usr/local/bin/drush -r /var/www sql-query 'SELECT COUNT(*) FROM {{ (drupal_mysql_prefix != '') | ternary(drupal_mysql_prefix  + '_', '') }}system WHERE name = \"set_environment\" AND status = 1;'"
   when: drupal_site_install.skipped
   tags: update
   register: drupal_enabled_set_env

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -174,7 +174,7 @@
   tags: update
 
 - name: Check if Drupal Features are enabled
-  command: "/usr/local/bin/drush -r /var/www sql-query 'SELECT COUNT(*) FROM {{ (drupal_mysql_prefix != '') | ternary(drupal_mysql_prefix  + '_', '') }}system WHERE name = \"features\" AND status = 1;'"
+  command: "/usr/local/bin/drush -r /var/www sql-query 'SELECT COUNT(*) FROM {system} WHERE name = \"features\" AND status = 1;' --db-prefix"
   when: drupal_site_install.skipped
   tags: update
   register: drupal_enabled_features
@@ -193,7 +193,7 @@
   when: drupal_site_install.skipped
 
 - name: Check if Drupal Set Environment is enabled
-  command: "/usr/local/bin/drush -r /var/www sql-query 'SELECT COUNT(*) FROM {{ (drupal_mysql_prefix != '') | ternary(drupal_mysql_prefix  + '_', '') }}system WHERE name = \"set_environment\" AND status = 1;'"
+  command: "/usr/local/bin/drush -r /var/www sql-query 'SELECT COUNT(*) FROM {system} WHERE name = \"set_environment\" AND status = 1;' --db-prefix"
   when: drupal_site_install.skipped
   tags: update
   register: drupal_enabled_set_env

--- a/templates/settings.php.j2
+++ b/templates/settings.php.j2
@@ -11,7 +11,7 @@ $databases = array (
       'password' => '{{ drupal_mysql_password }}',
       'host' => 'localhost',
       'port' => '3306',
-      'prefix' => '',
+      'prefix' => '{{ drupal_mysql_prefix }}',
     ),
   ),
 );


### PR DESCRIPTION
Add optional DB prefix to settings.php (and to defaults/main.yml and the docs). Changed tasks to use drush sql-query so they obey the prefix. Added root -r to drush invocation so it knows drupal.