### PR TITLE
added a missing apt package and missing boto packages to ensure MySQL…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -244,37 +244,54 @@
     chdir: "{{ doc_root }}"
   when: not restore_files_backup
 
-# Obtain Drupal Status output, retry 3 times to try to force those errors out
-- name: Fetching Drupal Status Report
-  command: "drush status-report --format=json"
+## Obtain Drupal Status output, retry 3 times to try to force those errors out
+#- name: Fetching Drupal Status Report
+#  command: "drush status-report --format=json"
+#  args:
+#    chdir: "{{ doc_root }}"
+#  register: status_report_command_result
+#  until: (status_report_command_result.stdout | from_json).values() | selectattr('severity', 'equalto', 'Error') | selectattr('description', 'search', 'There was a problem checking available updates') | list | length == 0
+#  retries: 3
+#  delay: 10
+
+#- name: Validate Drupal status report command result
+#  fail: msg="Command returned a non-zero status - {{ status_report_command_result }}"
+#  when: status_report_command_result.rc != 0
+      
+#- name: Convert Drupal status report from json
+#  set_fact:
+#    drupal_status_report__: "{{ status_report_command_result.stdout | from_json }}"
+
+#- name: Find out Drupal version
+#  set_fact:
+#    drupal_version__: "{{ drupal_status_report__.drupal.value }}"
+
+#- debug: 
+#  msg: "Drupal version set to {{ drupal_version__ }}"
+
+#- name: Obtain Drupal Version
+#  command: "echo '{{ drupal_version__ }}'|cut -f1 -d."
+#  register: drupal_version_int
+
+
+
+- name: Obtain Drupal Status
+  shell: /usr/local/bin/drush status | grep "Drupal version"
   args:
     chdir: "{{ doc_root }}"
-  register: status_report_command_result
-  until: (status_report_command_result.stdout | from_json).values() | selectattr('severity', 'equalto', 'Error') | selectattr('description', 'search', 'There was a problem checking available updates') | list | length == 0
-  retries: 3
-  delay: 10
+  register: drupal_status
 
-- name: Validate Drupal status report command result
-  fail: msg="Command returned a non-zero status - {{ status_report_command_result }}"
-  when: status_report_command_result.rc != 0
-      
-- name: Convert Drupal status report from json
-  set_fact:
-    drupal_status_report__: "{{ status_report_command_result.stdout | from_json }}"
-
-- name: Find out Drupal version
-  set_fact:
-    drupal_version__: "{{ drupal_status_report__.drupal.value }}"
-
-- debug: 
-  msg: "Drupal version set to {{ drupal_version__ }}"
+- name: Debug drupal_status variable
+  debug: msg="{{ drupal_status }}"
 
 - name: Obtain Drupal Version
-  command: "echo '{{ drupal_version__ }}'|cut -f1 -d."
+  command: "echo '{{ drupal_status }}'|cut -d: -f2|tr ' ' ''|cut -f1 -d."
   register: drupal_version_int
 
 - name: Debug drupal_version variable
   debug: msg="{{ drupal_version_int }}"
+
+
 
 # Set site to use stage for assets (instead of downloading locally) for Drupal version <= v7
 - name: Set the stage URL for the stage_file_proxy module

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -285,7 +285,7 @@
   debug: msg="{{ drupal_status }}"
 
 - name: Obtain Drupal Version
-  shell: echo "{{ drupal_status.stdout }}"|cut -d: -f2|tr ' ' ''|cut -f1 -d.
+  shell: "echo '{{ drupal_status.stdout }}'|cut -d: -f2|tr ' ' ''|cut -f1 -d."
   register: drupal_version_int
 
 - name: Debug drupal_version variable

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -250,9 +250,15 @@
     chdir: "{{ doc_root }}"
   register: drupal_status
 
+- name: Debug drupal_status variable
+  debug: msg="{{ drupal_status }}"
+
 - name: Obtain Drupal Version
-  command: "echo {{ drupal_status }}|grep 'Drupal version'|cut -d: -f2|tr ' ' ''|cut -f1 -d."
+  command: "echo '{{ drupal_status }}'|grep 'Drupal version'|cut -d: -f2|tr ' ' ''|cut -f1 -d."
   register: drupal_version
+
+- name: Debug drupal_version variable
+  debug: msg="{{ drupal_version }}"
 
 # Set site to use stage for assets (instead of downloading locally) for Drupal version <= v7
 - name: Set the stage URL for the stage_file_proxy module

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -285,8 +285,7 @@
   debug: msg="{{ drupal_status.stdout }}"
 
 - name: Obtain Drupal Version
-  shell: "echo {{ drupal_status.stdout | replace(' ', '') | quote }} | cut -d: -f2 | cut -f2 -d."
-  register: drupal_version_int
+  set_fact: drupal_version_int "{{ drupal_status.stdout | replace(' ', '') | regex_replace(':([0-9]{1,2})\.', '\1') }}"
 
 - name: Debug drupal_version variable
   debug: msg="{{ drupal_version_int.stdout }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -244,37 +244,6 @@
     chdir: "{{ doc_root }}"
   when: not restore_files_backup
 
-## Obtain Drupal Status output, retry 3 times to try to force those errors out
-#- name: Fetching Drupal Status Report
-#  command: "drush status-report --format=json"
-#  args:
-#    chdir: "{{ doc_root }}"
-#  register: status_report_command_result
-#  until: (status_report_command_result.stdout | from_json).values() | selectattr('severity', 'equalto', 'Error') | selectattr('description', 'search', 'There was a problem checking available updates') | list | length == 0
-#  retries: 3
-#  delay: 10
-
-#- name: Validate Drupal status report command result
-#  fail: msg="Command returned a non-zero status - {{ status_report_command_result }}"
-#  when: status_report_command_result.rc != 0
-      
-#- name: Convert Drupal status report from json
-#  set_fact:
-#    drupal_status_report__: "{{ status_report_command_result.stdout | from_json }}"
-
-#- name: Find out Drupal version
-#  set_fact:
-#    drupal_version__: "{{ drupal_status_report__.drupal.value }}"
-
-#- debug: 
-#  msg: "Drupal version set to {{ drupal_version__ }}"
-
-#- name: Obtain Drupal Version
-#  command: "echo '{{ drupal_version__ }}'|cut -f1 -d."
-#  register: drupal_version_int
-
-
-
 - name: Obtain Drupal Status
   shell: /usr/local/bin/drush status | grep "Drupal version"
   args:
@@ -289,8 +258,6 @@
 
 - name: Debug drupal_version variable
   debug: msg="{{ drupal_version_int }}"
-
-
 
 # Set site to use stage for assets (instead of downloading locally) for Drupal version <= v7
 - name: Set the stage URL for the stage_file_proxy module

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -285,7 +285,7 @@
   debug: msg="{{ drupal_status.stdout }}"
 
 - name: Obtain Drupal Version
-  shell: "echo '{{ drupal_status.stdout }}'|cut -d: -f2|tr -s ' '|tr ' ' '.'|cut -f2 -d."
+  shell: "echo {{ drupal_status.stdout | replace(' ', '') | quote }} | cut -d: -f2 | cut -f2 -d."
   register: drupal_version_int
 
 - name: Debug drupal_version variable

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -245,7 +245,7 @@
   when: not restore_files_backup
 
 - name: Obtain Drupal version
-  command: "drush status|grep 'Drupal version'|cut -d: -f2|sed -e 's/[[:space:]]*//g'|cut -f1 -d."
+  command: "drush status|grep 'Drupal version'|cut -d: -f2|tr ' ' ''|cut -f1 -d."
   args:
     chdir: "{{ doc_root }}"
   register: drupal_version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -245,7 +245,7 @@
   when: not restore_files_backup
 
 - name: Obtain Drupal Status
-  command: "/usr/bin/local/drush status"
+  command: "/usr/local/bin/drush status"
   args:
     chdir: "{{ doc_root }}"
   register: drupal_status

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -245,7 +245,7 @@
   when: not restore_files_backup
 
 - name: Obtain Drupal Status
-  command: "/usr/local/bin/drush status"
+  shell: /usr/local/bin/drush status | grep "Drupal version"
   args:
     chdir: "{{ doc_root }}"
   register: drupal_status

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -250,19 +250,19 @@
     chdir: "{{ doc_root }}"
   register: drupal_version
 
-# Set site to use stage for assets (instead of downloading locally) for Drupal version < 8
+# Set site to use stage for assets (instead of downloading locally) for Drupal version <= v7
 - name: Set the stage URL for the stage_file_proxy module
   command: "/usr/local/bin/drush variable-set stage_file_proxy_origin '{{ drupal_stage_site_url }}'"
   args:
     chdir: "{{ doc_root }}"
-  when: not restore_files_backup and drupal_version.stdout|int < 8
+  when: not restore_files_backup and drupal_version.stdout|int <= 7
 
-# Set site to use stage for assets (instead of downloading locally) for Drupal version > 7
+# Set site to use stage for assets (instead of downloading locally) for Drupal version >= v8
 - name: Set the stage URL for the stage_file_proxy module
   command: "drush config-set stage_file_proxy.settings origin '{{ drupal_stage_site_url }}' -y"
   args:
     chdir: "{{ doc_root }}"
-  when: not restore_files_backup and drupal_version.stdout|int > 7
+  when: not restore_files_backup and drupal_version.stdout|int >= 8
 
 # Download and enable the devel module
 - name: Install the devel drupal module

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -244,10 +244,14 @@
     chdir: "{{ doc_root }}"
   when: not restore_files_backup
 
-- name: Obtain Drupal version
-  command: "drush status|grep 'Drupal version'|cut -d: -f2|tr ' ' ''|cut -f1 -d."
+- name: Obtain Drupal Status
+  command: "/usr/bin/local/drush status"
   args:
     chdir: "{{ doc_root }}"
+  register: drupal_status
+
+- name: Obtain Drupal Version
+  command: "echo {{ drupal_status }}|grep 'Drupal version'|cut -d: -f2|tr ' ' ''|cut -f1 -d."
   register: drupal_version
 
 # Set site to use stage for assets (instead of downloading locally) for Drupal version <= v7

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
     name: "{{ item }}"
   with_items:
     - sendmail-bin
+    - libmysqlclient-dev
 
 - name: Install pip modules
   pip:
@@ -11,6 +12,8 @@
   with_items:
     - MySQL-python
     - boto
+    - boto3
+    - botocore
 
 - name: Create any additional non-drupal databases
   mysql_db:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -285,7 +285,7 @@
   debug: msg="{{ drupal_status.stdout }}"
 
 - name: Obtain Drupal Version
-  set_fact: drupal_version_int="{{ drupal_status.stdout | replace(' ', '') | regex_replace(':([0-9]{1,2})\.', '\1') }}"
+  set_fact: drupal_version_int="{{ drupal_status.stdout | replace(' ', '') | regex_replace('[a-zA-Z]+:([0-9]{1,2})\.[0-9]+\.[0-9]+', '\1') }}"
 
 - name: Debug drupal_version variable
   debug: msg="{{ drupal_version_int }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -244,35 +244,51 @@
     chdir: "{{ doc_root }}"
   when: not restore_files_backup
 
-- name: Obtain Drupal Status
-  shell: /usr/local/bin/drush status | grep "Drupal version"
+# Obtain Drupal Status output, retry 3 times to try to force those errors out
+- name: Fetching Drupal Status Report
+  command: "drush status-report --format=json"
   args:
     chdir: "{{ doc_root }}"
-  register: drupal_status
+  register: status_report_command_result
+  until: (status_report_command_result.stdout | from_json).values() | selectattr('severity', 'equalto', 'Error') | selectattr('description', 'search', 'There was a problem checking available updates') | list | length == 0
+  retries: 3
+  delay: 10
 
-- name: Debug drupal_status variable
-  debug: msg="{{ drupal_status }}"
+- name: Validate Drupal status report command result
+  fail: msg="Command returned a non-zero status - {{ status_report_command_result }}"
+  when: status_report_command_result.rc != 0
+      
+- name: Convert Drupal status report from json
+  set_fact:
+    drupal_status_report__: "{{ status_report_command_result.stdout | from_json }}"
+
+- name: Find out Drupal version
+  set_fact:
+    drupal_version__: "{{ drupal_status_report__.drupal.value }}"
+
+- debug: 
+  msg: "Drupal version set to {{ drupal_version__ }}"
 
 - name: Obtain Drupal Version
-  command: "echo '{{ drupal_status }}'|grep 'Drupal version'|cut -d: -f2|tr ' ' ''|cut -f1 -d."
-  register: drupal_version
+  command: "echo '{{ drupal_version__ }}'|cut -f1 -d."
+  register: drupal_version_int
 
 - name: Debug drupal_version variable
-  debug: msg="{{ drupal_version }}"
+  debug: msg="{{ drupal_version_int }}"
 
 # Set site to use stage for assets (instead of downloading locally) for Drupal version <= v7
 - name: Set the stage URL for the stage_file_proxy module
   command: "/usr/local/bin/drush variable-set stage_file_proxy_origin '{{ drupal_stage_site_url }}'"
   args:
     chdir: "{{ doc_root }}"
-  when: not restore_files_backup and drupal_version.stdout|int <= 7
+  when: not restore_files_backup and drupal_version_int.stdout|int <= 7
 
 # Set site to use stage for assets (instead of downloading locally) for Drupal version >= v8
 - name: Set the stage URL for the stage_file_proxy module
   command: "drush config-set stage_file_proxy.settings origin '{{ drupal_stage_site_url }}' -y"
   args:
     chdir: "{{ doc_root }}"
-  when: not restore_files_backup and drupal_version.stdout|int >= 8
+  when: not restore_files_backup and drupal_version_int.stdout|int >= 8
 
 # Download and enable the devel module
 - name: Install the devel drupal module

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -244,12 +244,25 @@
     chdir: "{{ doc_root }}"
   when: not restore_files_backup
 
-# Set site to use stage for assets (instead of downloading locally)
+- name: Obtain Drupal version
+  command: "drush status|grep 'Drupal version'|cut -d: -f2|sed -e 's/^\s*//g'|cut -f1 -d."
+  args:
+    chdir: "{{ doc_root }}"
+  register: drupal_version
+
+# Set site to use stage for assets (instead of downloading locally) for Drupal version < 8
 - name: Set the stage URL for the stage_file_proxy module
   command: "/usr/local/bin/drush variable-set stage_file_proxy_origin '{{ drupal_stage_site_url }}'"
   args:
     chdir: "{{ doc_root }}"
-  when: not restore_files_backup
+  when: not restore_files_backup and drupal_version.stdout|int < 8
+
+# Set site to use stage for assets (instead of downloading locally) for Drupal version > 7
+- name: Set the stage URL for the stage_file_proxy module
+  command: "drush config-set stage_file_proxy.settings origin '{{ drupal_stage_site_url }}' -y"
+  args:
+    chdir: "{{ doc_root }}"
+  when: not restore_files_backup and drupal_version.stdout|int > 7
 
 # Download and enable the devel module
 - name: Install the devel drupal module

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -245,7 +245,7 @@
   when: not restore_files_backup
 
 - name: Obtain Drupal version
-  command: "drush status|grep 'Drupal version'|cut -d: -f2|sed -e 's/^\s*//g'|cut -f1 -d."
+  command: "drush status|grep 'Drupal version'|cut -d: -f2|sed -e 's/[[:space:]]*//g'|cut -f1 -d."
   args:
     chdir: "{{ doc_root }}"
   register: drupal_version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -282,10 +282,10 @@
   register: drupal_status
 
 - name: Debug drupal_status variable
-  debug: msg="{{ drupal_status }}"
+  debug: msg="{{ drupal_status.stdout }}"
 
 - name: Obtain Drupal Version
-  shell: "echo '{{ drupal_status.stdout }}'|cut -d: -f2|tr ' ' ''|cut -f1 -d."
+  shell: "echo '{{ drupal_status.stdout }}'|cut -d: -f2|tr -s ' '|tr ' ' '.'|cut -f2 -d."
   register: drupal_version_int
 
 - name: Debug drupal_version variable

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -285,11 +285,11 @@
   debug: msg="{{ drupal_status }}"
 
 - name: Obtain Drupal Version
-  command: "echo '{{ drupal_status.stdout }}'|cut -d: -f2|tr ' ' ''|cut -f1 -d."
+  shell: echo "{{ drupal_status.stdout }}"|cut -d: -f2|tr ' ' ''|cut -f1 -d.
   register: drupal_version_int
 
 - name: Debug drupal_version variable
-  debug: msg="{{ drupal_version_int }}"
+  debug: msg="{{ drupal_version_int.stdout }}"
 
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -285,10 +285,10 @@
   debug: msg="{{ drupal_status.stdout }}"
 
 - name: Obtain Drupal Version
-  set_fact: drupal_version_int "{{ drupal_status.stdout | replace(' ', '') | regex_replace(':([0-9]{1,2})\.', '\1') }}"
+  set_fact: drupal_version_int="{{ drupal_status.stdout | replace(' ', '') | regex_replace(':([0-9]{1,2})\.', '\1') }}"
 
 - name: Debug drupal_version variable
-  debug: msg="{{ drupal_version_int.stdout }}"
+  debug: msg="{{ drupal_version_int }}"
 
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -297,14 +297,14 @@
   command: "/usr/local/bin/drush variable-set stage_file_proxy_origin '{{ drupal_stage_site_url }}'"
   args:
     chdir: "{{ doc_root }}"
-  when: not restore_files_backup and drupal_version_int.stdout|int <= 7
+  when: not restore_files_backup and drupal_version_int|int <= 7
 
 # Set site to use stage for assets (instead of downloading locally) for Drupal version >= v8
 - name: Set the stage URL for the stage_file_proxy module
   command: "drush config-set stage_file_proxy.settings origin '{{ drupal_stage_site_url }}' -y"
   args:
     chdir: "{{ doc_root }}"
-  when: not restore_files_backup and drupal_version_int.stdout|int >= 8
+  when: not restore_files_backup and drupal_version_int|int >= 8
 
 # Download and enable the devel module
 - name: Install the devel drupal module

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -285,7 +285,7 @@
   debug: msg="{{ drupal_status.stdout }}"
 
 - name: Obtain Drupal Version
-  set_fact: drupal_version_int="{{ drupal_status.stdout | replace(' ', '') | regex_replace('[a-zA-Z]+:([0-9]{1,2})\.[0-9]+\.[0-9]+', '\1') }}"
+  set_fact: drupal_version_int="{{ drupal_status.stdout | replace(' ', '') | regex_replace('[a-zA-Z]+:([0-9]{1,2})\.*[0-9]*\.*[0-9]*', '\1') }}"
 
 - name: Debug drupal_version variable
   debug: msg="{{ drupal_version_int }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -285,7 +285,7 @@
   debug: msg="{{ drupal_status }}"
 
 - name: Obtain Drupal Version
-  command: "echo '{{ drupal_status }}'|cut -d: -f2|tr ' ' ''|cut -f1 -d."
+  command: "echo '{{ drupal_status.stdout }}'|cut -d: -f2|tr ' ' ''|cut -f1 -d."
   register: drupal_version_int
 
 - name: Debug drupal_version variable


### PR DESCRIPTION
… and S3 downloads worked with no problems

Environment creation in wildgarden and sassoon was failing with errors:

TASK [webhop.drupal-bootstrap-vagrant : Install pip modules] *******************
failed: [www-wildgarden-com] (item=MySQL-python) => {"changed": false, "cmd": "/usr/local/bin/pip2 install MySQL-python", "failed": true, "item": "MySQL-python", "msg": "stdout: Collecting MySQL-python\n  Downloading MySQL-python-1.2.5.zip (108kB)\n    Complete output from command python setup.py egg_info:\n    sh: 1: mysql_config: not found\n    Traceback (most recent call last):\n      File \"<string>\", line 1, in <module>\n      File \"/tmp/pip-build-MS3qup/MySQL-python/setup.py\", line 17, in <module>\n        metadata, options = get_config()\n      File \"setup_posix.py\", line 43, in get_config\n        libs = mysql_config(\"libs_r\")\n      File \"setup_posix.py\", line 25, in mysql_config\n        raise EnvironmentError(\"%s not found\" % (mysql_config.path,))\n    EnvironmentError: mysql_config not found\n    \n    ----------------------------------------\n\n:stderr: Command \"python setup.py egg_info\" failed with error code 1 in /tmp/pip-build-MS3qup/MySQL-python/\n"}
ok: [www-wildgarden-com] => (item=boto)



TASK [webhop.drupal-bootstrap-vagrant : Retrieve DB backup from s3] ************
fatal: [www-sassoon-com]: FAILED! => {"changed": false, "failed": true, "msg": "boto3 and botocore required for this module"}