### PR TITLE
Change Drush command for D8 vagrant development environment

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -237,7 +237,7 @@
   register: drupal_enabled_features
 
 - name: Reverting Drupal Features
-  command: "/usr/local/bin/drush -r /var/www features-revert-all -y"
+  command: "/usr/local/bin/drush -r /var/www fra -y"
   when: drupal_enabled_features is defined and drupal_enabled_features|success
   tags: update
 


### PR DESCRIPTION
Hi @njsaunders , @codesplicer and @mbarcia .

I'd like to propose a pull request to fix Vagrant issue on Drupal 8.

Right now during Ansible provision there is an error during `/usr/local/bin/drush -r /var/www features-revert-all -y` command. It says that:
>The drush command `features-revert-all` could not be found.  Run `drush cache-clear drush` to clear the commandfile cache if you have installed new extensions.
It's caused with changes between D7 and D8 Features module.

In D7 there is `drush features-revert-all` command which revert all enabled feature module on site (https://drushcommands.com/drush-7x/features/features-revert-all/). There is an alias for this command - `drush fra`.

In D8 this command doesn't exists. But there is `drush features-import-all` command (https://drushcommands.com/drush-8x/features/features-import-all/). There is an alias for this command - `drush fra`. You can read on https://www.drupal.org/project/features/issues/2693831 why it was created.

I think, that we can replace `features-revert-all` into `fra` because `features-import-all` in D8 does same thing that `features-revert-all` in D7.

Let me know, what do you think about this.