### PR TITLE
Fix updatedb argument to cache-clear from clear-cache

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -218,7 +218,7 @@
   tags: update
 
 - name: "Updating Drupal DB schema if applicable (may fail)"
-  command: "/usr/local/bin/drush -r /var/www updatedb --clear-cache=0 -y"
+  command: "/usr/local/bin/drush -r /var/www updatedb --cache-clear=0 -y"
   register: updatedb_output
   when: updatedb_status_output.stdout is defined and 'No database updates required' not in updatedb_status_output.stdout
   ignore_errors: yes


### PR DESCRIPTION
Hi @pobtastic and @mbarcia,

during development on adidasbodycare I find out that **Updating Drupal DB schema if applicable (may fail)** is failing all the time.

I noticed that result of this task is as follows:
```
vagrant@www-adidasbodycare-com:/var/www$ /usr/local/bin/drush -r /var/www updatedb --clear-cache=0 -y
Unknown option: --clear-cache.  See `drush help updatedb` for available options. To suppress this error, add the option --strict=0.
```
I executed drush updatedb --help, and the result was:
```
vagrant@www-adidasbodycare-com:/var/www$ drush updatedb --help
Apply any database updates required (as with running update.php).

Options:
 --cache-clear=<0>                         If 0, Drush skips normal cache clearing; the caller should then clear if needed.                     
 --entity-updates                          Run automatic entity schema updates at the end of any update hooks. Defaults to --no-entity-updates.

Aliases: updb
```
As you can see option should be called `--cache-clear`, not `--clear-cache`. 

Please review this PR.

Also please let me know, does this code was executed on staging/live environment, or only on local vagrant machines. If it was also on staging/live environment how is it possible, that DB schema was updates?