### PR TITLE
We cannot use drush until we have a database.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,9 +38,51 @@
     - localhost
   when: drupal_mysql_user != 'root'
 
-- name: Check for existence of Drupal database
-  command: '/usr/bin/mysql -N -s -u {{ drupal_mysql_user }} -p{{ drupal_mysql_password }} -e "SELECT COUNT(1) FROM information_schema.tables WHERE table_schema=''drupal'';"'
-  register: drupal_table_count
+- name: Check if Drupal can be bootstrapped
+  command: /usr/local/bin/drush status-report
+  args:
+    chdir: "{{ doc_root }}"
+  ignore_errors: yes
+  no_log: true
+  register: drupal_bootstrapped
+
+- name: Checking if any DB backup is already downloaded
+  stat:
+    path: "/tmp/{{ database_backup_name }}"
+  register: drupal_db_dump
+
+- name: Retrieve full DB backup from s3
+  s3:
+    region: "{{ region }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    mode: get
+    bucket: "{{ s3_bucket }}"
+    object: "{{ database_backup_name }}"
+    dest: "/tmp/{{ database_backup_name }}"
+  when: (not drupal_db_dump.stat.exists) and restore_db_backup and db_backup_url is not defined
+
+- name: Import the full DB backup
+  mysql_db:
+    state: import
+    name: "{{ drupal_mysql_database }}"
+    target: "/tmp/{{ database_backup_name }}"
+  when: drupal_bootstrapped.rc != 0 and restore_db_backup and db_backup_url is not defined
+
+# What if we want to restore DB from a 'public' store?
+- name: Retrieve sanitised DB backup
+  get_url:
+    url: "{{ db_backup_url }}"
+    dest: "/tmp/{{ database_backup_name }}"
+  when: (not drupal_db_dump.stat.exists) and restore_db_backup and db_backup_url is defined
+
+# Extract DB backup
+- name: Import the sanitised DB backup
+  mysql_db:
+    state: import
+    name: "{{ drupal_mysql_database }}"
+    target: "/tmp/{{ database_backup_name }}"
+  when: drupal_bootstrapped.rc != 0 and restore_db_backup and db_backup_url is defined
 
 - name: Fetching Drupal Status
   command: "/usr/local/bin/drush status --format=json"
@@ -92,40 +134,9 @@
 - name: Move the drupal settings file from tmp to webroot
   command: "mv /tmp/drupal_settings.php {{ doc_root }}/sites/default/settings.php"
 
-- name: Check if Drupal can be bootstrapped
-  command: /usr/local/bin/drush status-report
-  args:
-    chdir: "{{ doc_root }}"
-  ignore_errors: yes
-  no_log: true
-  register: drupal_bootstrapped
-
 - name: Setting timestamp fact for naming purposes
   set_fact: epoch="{{ lookup('pipe','date +%Y%m%d%H%M%S') }}"
   when: restore_db_backup or restore_files_backup
-
-- name: Checking if DB backup is already downloaded
-  stat:
-    path: "/tmp/{{ database_backup_name }}"
-  register: drupal_db_dump
-
-- name: Retrieve DB backup from s3
-  s3:
-    region: "{{ region }}"
-    aws_access_key: "{{ aws_access_key }}"
-    aws_secret_key: "{{ aws_secret_key }}"
-    mode: get
-    bucket: "{{ s3_bucket }}"
-    object: "{{ database_backup_name }}"
-    dest: "/tmp/{{ database_backup_name }}"
-  when: (not drupal_db_dump.stat.exists) and restore_db_backup and db_backup_url is not defined
-
-- name: Import the DB backup
-  mysql_db:
-    state: import
-    name: "{{ drupal_mysql_database }}"
-    target: "/tmp/{{ database_backup_name }}"
-  when: drupal_bootstrapped.rc != 0 and restore_db_backup and db_backup_url is not defined
 
 - name: Retrieve files backup from s3
   s3:
@@ -147,21 +158,6 @@
     group: www-data
     copy: no
   when: restore_files_backup
-
-# What if we want to restore DB from a 'public' store?
-- name: Retrieve sanitised DB backup
-  get_url:
-    url: "{{ db_backup_url }}"
-    dest: "/tmp/db_backup.sql.gz"
-  when: db_backup_url is defined
-
-# Extract DB backup
-- name: Import the DB backup
-  mysql_db:
-    state: import
-    name: "{{ drupal_mysql_database }}"
-    target: "/tmp/db_backup.sql.gz"
-  when: db_backup_url is defined
 
 - name: Ensure files directory exists and is owned by www-data
   file:


### PR DESCRIPTION
I've been telling agencies to use vagrant...

Note that I've done away with manually naming the database when it's sanitised, you can only do one or the other so who cares if it has the same name.

I've also dropped `drupal_table_count` because it wasn't being used (and who cares?!  We only really want to know if we can bootstrap Drupal)

~WIP as I'm currently testing it with Bourjois.~ 

```
- extracting webhop.drupal-bootstrap-vagrant to /vagrant/ansible/roles/webhop.drupal-bootstrap-vagrant
- webhop.drupal-bootstrap-vagrant (fix-first-boot) was installed successfully
- extracting geerlingguy.memcached to /vagrant/ansible/roles/geerlingguy.memcached
```
...
```

TASK [webhop.drupal-bootstrap-vagrant : Create a MySQL user for Drupal.] *******
ok: [www-bourjois-com] => (item=127.0.0.1)
ok: [www-bourjois-com] => (item=::1)
ok: [www-bourjois-com] => (item=localhost)

TASK [webhop.drupal-bootstrap-vagrant : Check if Drupal can be bootstrapped] ***
fatal: [www-bourjois-com]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": true}
...ignoring

TASK [webhop.drupal-bootstrap-vagrant : Checking if DB backup is already downloaded] ***
ok: [www-bourjois-com]

TASK [webhop.drupal-bootstrap-vagrant : Retrieve DB backup from s3] ************
skipping: [www-bourjois-com]

TASK [webhop.drupal-bootstrap-vagrant : Import the DB backup] ******************
changed: [www-bourjois-com]

TASK [webhop.drupal-bootstrap-vagrant : Retrieve sanitised DB backup] **********
skipping: [www-bourjois-com]

TASK [webhop.drupal-bootstrap-vagrant : Import the DB backup] ******************
skipping: [www-bourjois-com]

TASK [webhop.drupal-bootstrap-vagrant : Fetching Drupal Status] ****************
```