### PR TITLE
Don't run pm-xxx actions on D8.x

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -269,14 +269,13 @@
   command: "/usr/local/bin/drush pm-download stage_file_proxy -y"
   args:
     chdir: "{{ doc_root }}"
-  when: not restore_files_backup
+  when: not restore_files_backup and drupal_version__ | version_compare('8.0', '<') and drupal_version__ | version_compare('7.0', '>=')
 
 - name: Enable the stage_file_proxy module
   command: "/usr/local/bin/drush pm-enable stage_file_proxy -y"
   args:
     chdir: "{{ doc_root }}"
-  when: not restore_files_backup
-
+  when: not restore_files_backup and drupal_version__ | version_compare('8.0', '<') and drupal_version__ | version_compare('7.0', '>=')
 
 # Set site to use stage for assets (instead of downloading locally) for Drupal version v7
 - name: Set the stage URL for the stage_file_proxy module for v7
@@ -297,8 +296,10 @@
   command: "/usr/local/bin/drush pm-download devel -y"
   args:
     chdir: "{{ doc_root }}"
+  when: drupal_version__ | version_compare('8.0', '<') and drupal_version__ | version_compare('7.0', '>=')
 
 - name: Enable the devel module
   command: "/usr/local/bin/drush pm-enable devel -y"
   args:
     chdir: "{{ doc_root }}"
+  when: drupal_version__ | version_compare('8.0', '<') and drupal_version__ | version_compare('7.0', '>=')


### PR DESCRIPTION
Where not present pm-xxx actions should not be run, as modules are managed via composer and usage causes an exception.

```
TASK [webhop.drupal-bootstrap-vagrant : Install the stage_file_proxy drupal module] ***
fatal: [www-truthabouthaircolor-com]: FAILED! => {"changed": true, "cmd": ["/usr/local/bin/drush", "pm-download", "stage_file_proxy", "-y"], "delta": "0:00:08.324915", "end": "2018-03-29 08:36:43.680456", "msg": "non-zero return code", "rc": 1, "start": "2018-03-29 08:36:35.355541", "stderr": "This codebase is assembled with Composer instead of Drush. Use           [error]\n`composer update` and `composer require` instead of `drush\npm-updatecode` and `drush pm-download`. You may override this error\nby using the --pm-force option.", "stderr_lines": ["This codebase is assembled with Composer instead of Drush. Use           [error]", "`composer update` and `composer require` instead of `drush", "pm-updatecode` and `drush pm-download`. You may override this error", "by using the --pm-force option."], "stdout": "", "stdout_lines": []}
	to retry, use: --limit @/vagrant/ansible/vagrant.retry

PLAY RECAP *********************************************************************
www-truthabouthaircolor-com : ok=110  changed=24   unreachable=0    failed=1   

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

Whilst we could use the suggested `--pm-force` this is only available in ONE version of drush, and it's dropped shortly afterwards (meaning we'd be stuck on this version).  This _can_ be managed with composer though via `require-dev`, so let's maybe stick with that for now.

Additional checks leading to a successful boot;

```
TASK [webhop.drupal-bootstrap-vagrant : Install the devel drupal module] *******
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using 
`result|version_compare` instead use `result is version_compare`. This feature 
will be removed in version 2.9. Deprecation warnings can be disabled by setting
 deprecation_warnings=False in ansible.cfg.
skipping: [www-truthabouthaircolor-com]

TASK [webhop.drupal-bootstrap-vagrant : Enable the devel module] ***************
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using 
`result|version_compare` instead use `result is version_compare`. This feature 
will be removed in version 2.9. Deprecation warnings can be disabled by setting
 deprecation_warnings=False in ansible.cfg.
skipping: [www-truthabouthaircolor-com]

TASK [Restart PHP FPM] *********************************************************
changed: [www-truthabouthaircolor-com]

TASK [Restart Apache2] *********************************************************
changed: [www-truthabouthaircolor-com]

PLAY RECAP *********************************************************************
www-truthabouthaircolor-com : ok=112  changed=21   unreachable=0    failed=0   
```

**NOTE** that the part which applies the config for stage_file_proxy already uses these same checks (they are not new).