### PR TITLE
Ensures Fastly isn't being used locally.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -233,6 +233,17 @@
   when: updatedb_output|failed
   tags: update
 
+- name: Disables the D7 Fastly integration for vagrant
+  command: "/usr/local/bin/drush pm-disable fastly -y"
+  args:
+    chdir: "{{ doc_root }}"
+  when: drupal_version__ | version_compare('8.0', '<') and drupal_version__ | version_compare('7.0', '>=')
+
+- name: Uninstalls the Fastly integration for vagrant
+  command: "/usr/local/bin/drush pm-uninstall fastly -y"
+  args:
+    chdir: "{{ doc_root }}"
+
 - name: Check if Drupal Features are enabled
   shell: "/usr/local/bin/drush pm-list | grep '(features)' | grep Enabled"
   args:

--- a/templates/settings.drupal7.php.j2
+++ b/templates/settings.drupal7.php.j2
@@ -83,6 +83,13 @@ $conf['environment_indicator_overwritten_color'] = '#205f20';
 $conf['set_environment_domain_search']   = '.com';
 $conf['set_environment_domain_replace']  = '.dev';
 
+// Ensure no database config from production persists locally.
+$conf['fastly_api_key'] = '';
+$conf['fastly_service_id'] = '';
+// 1 => FASTLY_DEFAULT_CLEAR.
+$conf['fastly_cache_clear'] = 1;
+// 0 => EXPIRE_STATUS_DISABLED.
+$conf['expire_status'] = 0;
 $conf['reverse_proxy'] = FALSE;
 
 if (function_exists('conf_path')) { // allow this file to be sourced regardless of whether drupal is bootstrapped

--- a/templates/settings.drupal8.php.j2
+++ b/templates/settings.drupal8.php.j2
@@ -41,11 +41,11 @@ $settings['hash_salt'] = 'ce65aefe7e22bc7c92398jf32j3ew8a0ab6c349ede1eea011251fe
 $settings['error_level'] = 0;
 
 // Cache settings.
-$settings['cache'] = 1;
-$settings['preprocess_css'] = 1;
+$settings['cache'] = 0;
+$settings['preprocess_css'] = 0;
 $settings['css_gzip_compression'] = 0;
 $settings['advagg_gzip'] = 0;
-$settings['preprocess_js'] = 1;
+$settings['preprocess_js'] = 0;
 $settings['js_gzip_compression'] = 0;
 $settings['cache_lifetime'] = 0;
 $settings['page_cache_maximum_age'] = 86400;
@@ -77,6 +77,10 @@ $settings['beamly_webhop_environment'] = 'development';
 // AWS Credentials (used by s3fs module)
 $settings['awssdk2_use_instance_profile'] = TRUE;
 $settings['awssdk2_default_cache_config'] = '/tmp/aws_credentials';
+
+// Ensure no database config from production persists locally.
+$config['fastly.settings']['api_key'] = '';
+$config['fastly.settings']['service_id'] = '';
 
 if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
   include $app_root . '/' . $site_path . '/settings.local.php';


### PR DESCRIPTION
If the production database contains the api and service keys (it shouldn't, but some sites were set up manually) then these will persist locally in vagrant.